### PR TITLE
Fix conversion of union types

### DIFF
--- a/transformer.ts
+++ b/transformer.ts
@@ -845,7 +845,7 @@ function convertUnionType(
 
   const nodes = type.aliasSymbol?.declarations
 
-  const types = nodes !== undefined && nodes.length !== 0
+  const types = nodes !== undefined && nodes.length !== 0 && (<any>nodes[0]).type !== undefined
     ? (<any>nodes[0]).type.types.map(typeChecker.getTypeFromTypeNode)
     : type.types
 


### PR DESCRIPTION
Adding safety check - code was blowing up on embedded enums, which seemed to have no types once parsed