### PR TITLE
Using 'resolve' package to provide better typescript file module resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "11.13.4",
+                "@types/resolve": "^1.20.0",
+                "resolve": "^1.20.0",
                 "rimraf": "^2.7.1",
                 "rollup-plugin-commonjs": "^10.1.0",
                 "rollup-plugin-typescript2": "^0.24.3",
@@ -38,6 +40,12 @@
             "version": "11.13.4",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.4.tgz",
             "integrity": "sha512-+rabAZZ3Yn7tF/XPGHupKIL5EcAbrLxnTr/hgQICxbeuAfWtT0UZSfULE+ndusckBItcv4o6ZeOJplQikVcLvQ==",
+            "dev": true
+        },
+        "node_modules/@types/resolve": {
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.0.tgz",
+            "integrity": "sha512-SFT3jdUNlLkjxUWwH/0QjLiEsV38hjdDX8oMcX9jZAD8KWNzRLdg6INZE7UMz9O86b2BOHzA3dR8nF+DbonX2Q==",
             "dev": true
         },
         "node_modules/balanced-match": {
@@ -136,6 +144,12 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
+        "node_modules/function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
         "node_modules/glob": {
             "version": "7.1.6",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -158,6 +172,18 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
             "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
             "dev": true
+        },
+        "node_modules/has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "dependencies": {
+                "function-bind": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
         },
         "node_modules/inflight": {
             "version": "1.0.6",
@@ -182,6 +208,18 @@
             "peer": true,
             "peerDependencies": {
                 "fp-ts": "^2.5.0"
+            }
+        },
+        "node_modules/is-core-module": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+            "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+            "dev": true,
+            "dependencies": {
+                "has": "^1.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-reference": {
@@ -344,12 +382,16 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
-            "integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
             "dev": true,
             "dependencies": {
+                "is-core-module": "^2.2.0",
                 "path-parse": "^1.0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/rimraf": {
@@ -527,6 +569,12 @@
             "integrity": "sha512-+rabAZZ3Yn7tF/XPGHupKIL5EcAbrLxnTr/hgQICxbeuAfWtT0UZSfULE+ndusckBItcv4o6ZeOJplQikVcLvQ==",
             "dev": true
         },
+        "@types/resolve": {
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.0.tgz",
+            "integrity": "sha512-SFT3jdUNlLkjxUWwH/0QjLiEsV38hjdDX8oMcX9jZAD8KWNzRLdg6INZE7UMz9O86b2BOHzA3dR8nF+DbonX2Q==",
+            "dev": true
+        },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -611,6 +659,12 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
         "glob": {
             "version": "7.1.6",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -630,6 +684,15 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
             "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
             "dev": true
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
         },
         "inflight": {
             "version": "1.0.6",
@@ -653,6 +716,15 @@
             "integrity": "sha512-y5TTSa6VP6le0hhmIyN0dqEXkrZeJLeC5KApJq6VLci3UEKF80lZ+KuoUs02RhBxNWlrqSNxzfI7otLX1Euv8Q==",
             "peer": true,
             "requires": {}
+        },
+        "is-core-module": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+            "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.3"
+            }
         },
         "is-reference": {
             "version": "1.1.4",
@@ -784,11 +856,12 @@
             }
         },
         "resolve": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
-            "integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
             "dev": true,
             "requires": {
+                "is-core-module": "^2.2.0",
                 "path-parse": "^1.0.6"
             }
         },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     ],
     "devDependencies": {
         "@types/node": "11.13.4",
+        "@types/resolve": "^1.20.0",
+        "resolve": "^1.20.0",
         "rimraf": "^2.7.1",
         "rollup-plugin-commonjs": "^10.1.0",
         "rollup-plugin-typescript2": "^0.24.3",

--- a/transformer.ts
+++ b/transformer.ts
@@ -1,5 +1,6 @@
 import * as ts from 'typescript'
 import * as path from 'path'
+import * as resolve from 'resolve'
 
 
 // Settings
@@ -352,14 +353,8 @@ function getImportNodeRealPath(node: ts.ImportDeclaration): string {
   try {
     return require.resolve(nodePath)
   } catch(e) {
-    // in some cases it fails to resolve modules unless their file extension is included.
-    for (const extension of ['ts', 'tsx']) {
-        try {
-            return require.resolve(`${nodePath}.${extension}`)
-        } catch(e) { }
-    }
-    //if none of the extensions worked
-    throw e
+    // attempt to resolve file path with typescript extensions
+    return resolve.sync(nodePath, {extensions: ['.ts', '.tsx']})
   }
 }
 


### PR DESCRIPTION
Addressing #11 this adds the [`resolve` package](https://www.npmjs.com/package/resolve) which re-implements node.js module file resolution. This is needed because the built in `require` function is not intended to only support javascript files and will not properly exhaustively check for typescript file resolutions such as `./module/index.ts` when resolving `./module`. Because `resolve` re-implements this logic and is designed as a utility function it provides more flexibility in customizing module resolution and has an `extensions` option that allows for providing alternate extensions for module resolution.

While this is an improvement over the existing resolution fallback, I think the underlying issue here is that an external module resolution strategy is being used at all as opposed to the module resolution built into the typescript compiler. Another issue not using the compiler's module resolution causes is that it breaks typescript's optional [path aliasing](https://www.typescriptlang.org/tsconfig#paths) and makes this transformer incompatible with projects that use absolute pathing. [By using typescript's compiler to visit the imports and exports](https://github.com/madou/typescript-transformer-handbook#following-module-imports) it should support all the built in typescript module resolution features.